### PR TITLE
Fixed Storybook Introduction page

### DIFF
--- a/packages/design/stories/Introduction.mdx
+++ b/packages/design/stories/Introduction.mdx
@@ -1,6 +1,7 @@
 import { Meta } from "@storybook/addon-docs";
-import Readme from "../../../README.md?raw";
+import { Markdown } from "@storybook/blocks";
+import ReadMe from "../../../README.md?raw";
 
 <Meta title="Introduction" />
 
-<Readme />
+<Markdown>{ReadMe}</Markdown>


### PR DESCRIPTION
Trying to access Storybook Introduction page throws an error:
![image](https://github.com/lautr/initium-nuxt/assets/35883748/8fb3a8a1-770a-4378-b1f4-4bc64916a15d)

its related to Storybook not being able to parse the markdown from the Readme file.